### PR TITLE
remove mention of mixin in gemspec to facilitate docs publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.1
+  - remove mention of mixin in gemspec to facilitate docs publishing
+
 ## 0.1.0
 
 * Added the initial set of Logstash AWS plugins that ship with Logstash.

--- a/logstash-integration-aws.gemspec
+++ b/logstash-integration-aws.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-integration-aws"
-  s.version         = "0.1.0"
+  s.version         = "0.1.1"
   s.licenses        = ["Apache-2.0"]
   s.summary         = "Collection of Logstash plugins that integrate with AWS"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
       logstash-input-cloudwatch
       logstash-input-s3
       logstash-input-sqs
-      logstash-mixin-aws
       logstash-output-cloudwatch
       logstash-output-s3
       logstash-output-sns


### PR DESCRIPTION
Typically integration plugins should only list in the gemspec's "integration plugins" field the list of plugins it contains, not the mixins.