### PR TITLE
bump version to 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.0
+  - bump integration to upper bound of all underlying plugins versions (biggest is sqs output 6.x)
+  - this is necessary to facilitate versioning continuity between older standalone plugins and plugins within the integration
+
 ## 0.1.1
   - remove mention of mixin in gemspec to facilitate docs publishing
 

--- a/logstash-integration-aws.gemspec
+++ b/logstash-integration-aws.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-integration-aws"
-  s.version         = "0.1.1"
+  s.version         = "7.0.0"
   s.licenses        = ["Apache-2.0"]
   s.summary         = "Collection of Logstash plugins that integrate with AWS"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Bump integration to upper bound of all underlying plugins versions (biggest is sqs output 6.x), so 7.0.0
This is necessary to facilitate versioning continuity between older standalone plugins and plugins within the integration
