### PR TITLE
Doc: Activate links and headers in source

### DIFF
--- a/docs/codec-cloudfront.asciidoc
+++ b/docs/codec-cloudfront.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: cloudfront
 :type: codec
 
@@ -17,7 +17,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Cloudfront codec plugin
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/codec-cloudtrail.asciidoc
+++ b/docs/codec-cloudtrail.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: cloudtrail
 :type: codec
 
@@ -17,7 +17,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Cloudtrail codec plugin
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -17,13 +17,12 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === AWS Integration Plugin
 
-// include::{include_path}/plugin_header.asciidoc[]
+include::{include_path}/plugin_header.asciidoc[]
 
 ==== Description
 
 The AWS Integration Plugin provides integrated plugins for working with Amazon Web Services:
 
-////
  - {logstash-ref}/plugins-codecs-cloudfront.html[Cloudfront Codec Plugin]
  - {logstash-ref}/plugins-codecs-cloudtrail.html[Cloudtrail Codec Plugin]
  - {logstash-ref}/plugins-inputs-cloudwatch.html[Cloudwatch Input Plugin]
@@ -33,6 +32,5 @@ The AWS Integration Plugin provides integrated plugins for working with Amazon W
  - {logstash-ref}/plugins-outputs-s3.html[S3 Output Plugin]
  - {logstash-ref}/plugins-outputs-sns.html[Sns Output Plugin]
  - {logstash-ref}/plugins-outputs-sqs.html[Sqs Output Plugin]
-////
 
 :no_codec!:

--- a/docs/input-cloudwatch.asciidoc
+++ b/docs/input-cloudwatch.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: cloudwatch
 :type: input
 :default_codec: plain
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Cloudwatch input plugin
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/input-s3.asciidoc
+++ b/docs/input-s3.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: s3
 :type: input
 :default_codec: plain
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === S3 input plugin
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/input-sqs.asciidoc
+++ b/docs/input-sqs.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: sqs
 :type: input
 :default_codec: json
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Sqs input plugin
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/output-cloudwatch.asciidoc
+++ b/docs/output-cloudwatch.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: cloudwatch
 :type: output
 :default_codec: plain
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Cloudwatch output plugin
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/output-s3.asciidoc
+++ b/docs/output-s3.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: s3
 :type: output
 :default_codec: line
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === S3 output plugin
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/output-sns.asciidoc
+++ b/docs/output-sns.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: sns
 :type: output
 :default_codec: plain
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Sns output plugin
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 

--- a/docs/output-sqs.asciidoc
+++ b/docs/output-sqs.asciidoc
@@ -1,4 +1,4 @@
-// :integration: aws
+:integration: aws
 :plugin: sqs
 :type: output
 :default_codec: json
@@ -18,7 +18,7 @@ END - GENERATED VARIABLES, DO NOT EDIT!
 
 === Sqs output plugin
 
-// include::{include_path}/plugin_header-integration.asciidoc[]
+include::{include_path}/plugin_header-integration.asciidoc[]
 
 ==== Description
 


### PR DESCRIPTION
Complete the final steps to activate the AWS integration docs:

- Activate integration header files (by removing comment slashes)
- Activate included plugin list (by removing comment slashes)

Related: https://github.com/elastic/logstash-docs/pull/1396