### PR TITLE
add explanation for role_arn setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 7.0.1
+  - [Doc] explain role_arn setting
+  
 ## 7.0.0
   - bump integration to upper bound of all underlying plugins versions (biggest is sqs output 6.x)
   - this is necessary to facilitate versioning continuity between older standalone plugins and plugins within the integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 7.0.1
-  - [Doc] explain role_arn setting
+  - [Doc] explain role_arn setting [#14](https://github.com/logstash-plugins/logstash-integration-aws/pull/14)
   
 ## 7.0.0
   - bump integration to upper bound of all underlying plugins versions (biggest is sqs output 6.x)

--- a/docs/input-sqs.asciidoc
+++ b/docs/input-sqs.asciidoc
@@ -238,6 +238,7 @@ The AWS Region
 The AWS IAM Role to assume, if any.
 This is used to generate temporary credentials, typically for cross-account access.
 See the https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html[AssumeRole API documentation] for more information.
+To use this feature, set `role_session_name`, remove `access_key_id` and `secret_access_key`, and use the aws credentials to setup the aws default profile for the primary account in the server.
 
 [id="plugins-{type}s-{plugin}-role_session_name"]
 ===== `role_session_name`
@@ -245,7 +246,7 @@ See the https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html[
   * Value type is <<string,string>>
   * Default value is `"logstash"`
 
-Session name to use when assuming an IAM role.
+Session name to use when assuming an IAM role. This is required for `role_arn`.
 
 [id="plugins-{type}s-{plugin}-secret_access_key"]
 ===== `secret_access_key` 

--- a/logstash-integration-aws.gemspec
+++ b/logstash-integration-aws.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-integration-aws"
-  s.version         = "7.0.0"
+  s.version         = "7.0.1"
   s.licenses        = ["Apache-2.0"]
   s.summary         = "Collection of Logstash plugins that integrate with AWS"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
In the doc, we never point out `role_sesseion_name` is required for `role_arn` and should not set `access_key_id` and `secret_access_key`.
The same description needs to update in input-cloudwatch, input-s3, input-sqs, output-s3 and output-sqs