### PR TITLE
s3 output: resolve stale-detection races

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 7.0.1
+  - resolves two closely-related race conditions in the S3 Output plugin's handling of stale temporary files that could cause plugin crashes or data-loss
+    - prevents a `No such file or directory` crash that could occur when a temporary file is accessed after it has been detected as stale (empty+old) and deleted.
+    - prevents a possible deletion of a non-empty temporary file that could occur if bytes were written to it _after_ it was detected as stale (empty+old) and _before_ the deletion completed.
+
 ## 7.0.0
   - bump integration to upper bound of all underlying plugins versions (biggest is sqs output 6.x)
   - this is necessary to facilitate versioning continuity between older standalone plugins and plugins within the integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 7.0.1
-  - resolves two closely-related race conditions in the S3 Output plugin's handling of stale temporary files that could cause plugin crashes or data-loss
+  - resolves two closely-related race conditions in the S3 Output plugin's handling of stale temporary files that could cause plugin crashes or data-loss [#19](https://github.com/logstash-plugins/logstash-integration-aws/pull/19)
     - prevents a `No such file or directory` crash that could occur when a temporary file is accessed after it has been detected as stale (empty+old) and deleted.
     - prevents a possible deletion of a non-empty temporary file that could occur if bytes were written to it _after_ it was detected as stale (empty+old) and _before_ the deletion completed.
 

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -258,6 +258,8 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
 
     @logger.debug("Uploading current workspace")
 
+    @file_repository.shutdown # stop stale sweeps
+
     # The plugin has stopped receiving new events, but we still have
     # data on disk, lets make sure it get to S3.
     # If Logstash get interrupted, the `restore_from_crash` (when set to true) method will pickup
@@ -266,8 +268,6 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
     @file_repository.each_files do |file|
       upload_file(file)
     end
-
-    @file_repository.shutdown
 
     @uploader.stop # wait until all the current upload are complete
     @crash_uploader.stop if @restore # we might have still work to do for recovery so wait until we are done
@@ -336,22 +336,21 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   end
 
   def rotate_if_needed(prefixes)
-    prefixes.each do |prefix|
-      # Each file access is thread safe,
-      # until the rotation is done then only
-      # one thread has access to the resource.
-      @file_repository.get_factory(prefix) do |factory|
-        temp_file = factory.current
 
-        if @rotation.rotate?(temp_file)
-          @logger.debug("Rotate file",
-                        :strategy => @rotation.class.name,
-                        :key => temp_file.key,
-                        :path => temp_file.path)
+    # Each file access is thread safe,
+    # until the rotation is done then only
+    # one thread has access to the resource.
+    @file_repository.each_factory(prefixes) do |factory|
+      temp_file = factory.current
 
-          upload_file(temp_file)
-          factory.rotate!
-        end
+      if @rotation.rotate?(temp_file)
+        @logger.debug("Rotate file",
+                      :strategy => @rotation.class.name,
+                      :key => temp_file.key,
+                      :path => temp_file.path)
+
+        upload_file(temp_file)
+        factory.rotate!
       end
     end
   end

--- a/lib/logstash/outputs/s3/file_repository.rb
+++ b/lib/logstash/outputs/s3/file_repository.rb
@@ -17,8 +17,9 @@ module LogStash
         class PrefixedValue
           def initialize(file_factory, stale_time)
             @file_factory = file_factory
-            @lock = Mutex.new
+            @lock = Monitor.new # reentrant Mutex
             @stale_time = stale_time
+            @is_deleted = false
           end
 
           def with_lock
@@ -36,7 +37,14 @@ module LogStash
           end
 
           def delete!
-            with_lock{ |factory| factory.current.delete! }
+            with_lock do |factory|
+              factory.current.delete!
+              @is_deleted = true
+            end
+          end
+
+          def deleted?
+            with_lock { |_| @is_deleted }
           end
         end
 
@@ -72,19 +80,70 @@ module LogStash
           @prefixed_factories.keySet
         end
 
+        ##
+        # Yields the current file of each non-deleted file factory while the current thread has exclusive access to it.
+        # @yieldparam file [TemporaryFile]
+        # @return [void]
         def each_files
-          @prefixed_factories.elements.each do |prefixed_file|
-            prefixed_file.with_lock { |factory| yield factory.current }
+          each_factory(keys) do |factory|
+            yield factory.current
           end
+          nil # void return avoid leaking unsynchronized access
         end
 
-        # Return the file factory
+        ##
+        # Yields the file factory while the current thread has exclusive access to it, creating a new
+        # one if one does not exist or if the current one is being reaped by the stale watcher.
+        # @param prefix_key [String]: the prefix key
+        # @yieldparam factory [TemporaryFileFactory]: a temporary file factory that this thread has exclusive access to
+        # @return [void]
         def get_factory(prefix_key)
-          @prefixed_factories.computeIfAbsent(prefix_key, @factory_initializer).with_lock { |factory| yield factory }
+          # fast-path: if factory exists and is not deleted, yield it with exclusive access and return
+          prefix_val = @prefixed_factories.get(prefix_key)
+          prefix_val&.with_lock do |factory|
+            # intentional local-jump to ensure deletion detection
+            # is done inside the exclusive access.
+            unless prefix_val.deleted?
+              yield(factory)
+              return nil # void return avoid leaking unsynchronized access
+            end
+          end
+
+          # slow-path:
+          # the ConcurrentHashMap#get operation is lock-free, but may have returned an entry that was being deleted by
+          # another thread (such as via stale detection). If we failed to retrieve a value, or retrieved one that had
+          # been marked deleted, use the atomic ConcurrentHashMap#compute to retrieve a non-deleted entry.
+          prefix_val = @prefixed_factories.compute(prefix_key) do |_, existing|
+            existing && !existing.deleted? ? existing : @factory_initializer.apply(prefix_key)
+          end
+          prefix_val.with_lock { |factory| yield factory }
+          nil # void return avoid leaking unsynchronized access
         end
 
+        ##
+        # Yields each non-deleted file factory while the current thread has exclusive access to it.
+        # @param prefixes [Array<String>]: the prefix keys
+        # @yieldparam factory [TemporaryFileFactory]
+        # @return [void]
+        def each_factory(prefixes)
+          prefixes.each do |prefix_key|
+            prefix_val = @prefixed_factories.get(prefix_key)
+            prefix_val&.with_lock do |factory|
+              yield factory unless prefix_val.deleted?
+            end
+          end
+          nil # void return avoid leaking unsynchronized access
+        end
+
+        ##
+        # Ensures that a non-deleted factory exists for the provided prefix and yields its current file
+        # while the current thread has exclusive access to it.
+        # @param prefix_key [String]
+        # @yieldparam file [TemporaryFile]
+        # @return [void]
         def get_file(prefix_key)
           get_factory(prefix_key) { |factory| yield factory.current }
+          nil # void return avoid leaking unsynchronized access
         end
 
         def shutdown
@@ -95,10 +154,21 @@ module LogStash
           @prefixed_factories.size
         end
 
-        def remove_stale(k, v)
-          if v.stale?
-            @prefixed_factories.remove(k, v)
-            v.delete!
+        def remove_if_stale(prefix_key)
+          # we use the ATOMIC `ConcurrentHashMap#computeIfPresent` to atomically
+          # detect the staleness, mark a stale prefixed factory as deleted, and delete from the map.
+          @prefixed_factories.computeIfPresent(prefix_key) do |_, prefixed_factory|
+            # once we have retrieved an instance, we acquire exclusive access to it
+            # for stale detection, marking it as deleted before releasing the lock
+            # and causing it to become deleted from the map.
+            prefixed_factory.with_lock do |_|
+              if prefixed_factory.stale?
+                prefixed_factory.delete!  # mark deleted to prevent reuse
+                nil # cause deletion
+              else
+                prefixed_factory # keep existing
+              end
+            end
           end
         end
 
@@ -106,7 +176,9 @@ module LogStash
           @stale_sweeper = Concurrent::TimerTask.new(:execution_interval => @sweeper_interval) do
             LogStash::Util.set_thread_name("S3, Stale factory sweeper")
 
-            @prefixed_factories.forEach{|k,v| remove_stale(k,v)}
+            @prefixed_factories.keys.each do |prefix|
+              remove_if_stale(prefix)
+            end
           end
 
           @stale_sweeper.execute

--- a/logstash-integration-aws.gemspec
+++ b/logstash-integration-aws.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = "logstash-integration-aws"
-  s.version         = "7.0.0"
+  s.version         = "7.0.1"
   s.licenses        = ["Apache-2.0"]
   s.summary         = "Collection of Logstash plugins that integrate with AWS"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This is largely a forward-port of logstash-plugins/logstash-output-s3#252 with some minor changes to deal with the integrated plugin's usage of the java-native `ConcurrentHashMap` in place of the stand-alone plugin's ruby-native `Concurrent::Map`.

Refactor of `S3::FileRepository` to avoid several closely-related race conditions:

 - prevent `get_factory()` from yielding a factory that was mid-deletion by the stale watcher, which could cause the plugin crash due to the file no longer existing on disk. This is solved by marking a factory's prefix wrapper as deleted while the stale watcher has exclusive access to it, and checking for deletion status before yielding exclusive access to a prefix wrapper's factory.
 - introduce `each_factory`, which _avoids_ creating new factories or yielding deleted ones.
 - refactor `each_files` to use new `each_factory` to avoid yielding files whose factories have been deleted.
 - void-return methods now explicitly emit `nil` to prevent accidental leaks of synchronization-required resources.

Additionally, `S3#rotate_if_needed` was migrated to use the now-safer `S3::FileRepository#each_factory` that _avoids_ initializing new factories (and therefore avoids creating empty files on disk after the existing ones had been stale-reaped).
