### PR TITLE
Track temp dirs and remove when staled.

### DIFF
--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -87,7 +87,9 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   include LogStash::PluginMixins::AwsConfig::V2
 
   PREFIX_KEY_NORMALIZE_CHARACTER = "_"
-  PERIODIC_CHECK_INTERVAL_IN_SECONDS = 15
+  PERIODIC_FILE_ROTATOR_INTERVAL_IN_SECONDS = 15
+  PERIODIC_STALE_SWEEPER_INTERVAL_IN_SECONDS = 60
+
   CRASH_RECOVERY_THREADPOOL = Concurrent::ThreadPoolExecutor.new({
                                                                    :min_threads => 1,
                                                                    :max_threads => 2,
@@ -114,7 +116,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
 
   # Set the time, in MINUTES, to close the current sub_time_section of bucket.
   # If you also define file_size you have a number of files related to the section and the current tag.
-  # If it's valued 0 and rotation_strategy is 'time' or 'size_and_time' then the plugin reaise a configuration error.
+  # If it's valued 0 and rotation_strategy is 'time' or 'size_and_time' then the plugin raise a configuration error.
   config :time_file, :validate => :number, :default => 15
 
   # If `restore => false` is specified and Logstash crashes, the unprocessed files are not sent into the bucket.
@@ -186,7 +188,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   config :rotation_strategy, :validate => ["size_and_time", "size", "time"], :default => "size_and_time"
 
   # The common use case is to define permission on the root bucket and give Logstash full access to write its logs.
-  # In some circonstances you need finer grained permission on subfolder, this allow you to disable the check at startup.
+  # In some circumstances you need finer grained permission on subfolder, this allow you to disable the check at startup.
   config :validate_credentials_on_root_bucket, :validate => :boolean, :default => true
 
   # The number of times to retry a failed S3 upload.
@@ -234,7 +236,9 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
 
     # If we need time based rotation we need to do periodic check on the file
     # to take care of file that were not updated recently
-    start_periodic_check if @rotation.needs_periodic?
+    start_periodic_file_rotator if @rotation.needs_periodic?
+
+    start_periodic_stale_sweeper
   end
 
   def multi_receive_encoded(events_and_encoded)
@@ -259,11 +263,10 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   end
 
   def close
-    stop_periodic_check if @rotation.needs_periodic?
+    stop_periodic_file_rotator if @rotation.needs_periodic?
+    stop_periodic_stale_sweeper # stop periodic stale sweeps
 
     @logger.debug("Uploading current workspace")
-
-    @file_repository.shutdown # stop stale sweeps
 
     # The plugin has stopped receiving new events, but we still have
     # data on disk, lets make sure it get to S3.
@@ -319,21 +322,40 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   end
 
   private
-  # We start a task in the background for check for stale files and make sure we rotate them to S3 if needed.
-  def start_periodic_check
-    @logger.debug("Start periodic rotation check")
+  # We start a task in the background to check at periodic cadence for file rotation.
+  # Rotated files are uploaded to S3 if their size > 0.
+  # Rotated files with size == 0 will be swept by stale sweeper.
+  def start_periodic_file_rotator
+    @logger.debug("Start periodic file rotation check")
 
-    @periodic_check = Concurrent::TimerTask.new(:execution_interval => PERIODIC_CHECK_INTERVAL_IN_SECONDS) do
-      @logger.debug("Periodic check for stale files")
+    @periodic_file_rotator = Concurrent::TimerTask.new(:execution_interval => PERIODIC_FILE_ROTATOR_INTERVAL_IN_SECONDS) do
+      @logger.debug("Periodic check for file rotation")
 
       rotate_if_needed(@file_repository.keys)
     end
 
-    @periodic_check.execute
+    @periodic_file_rotator.execute
   end
 
-  def stop_periodic_check
-    @periodic_check.shutdown
+  def start_periodic_stale_sweeper
+    @periodic_stale_sweeper = Concurrent::TimerTask.new(:execution_interval => PERIODIC_STALE_SWEEPER_INTERVAL_IN_SECONDS) do
+      LogStash::Util.set_thread_name("S3, Stale factory sweeper")
+
+      @logger.debug("Periodic stale sweeper check started.")
+      @file_repository.keys.each do | prefix_key |
+        @file_repository.remove_if_stale(prefix_key)
+      end
+    end
+
+    @periodic_stale_sweeper.execute
+  end
+
+  def stop_periodic_file_rotator
+    @periodic_file_rotator.shutdown
+  end
+
+  def stop_periodic_stale_sweeper
+    @periodic_stale_sweeper.shutdown
   end
 
   def bucket_resource

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -217,7 +217,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
       raise LogStash::ConfigurationError, "The S3 plugin must have at least one of time_file or size_file set to a value greater than 0"
     end
 
-    @file_repository = FileRepository.new(@tags, @encoding, @temporary_directory)
+    @file_repository = FileRepository.new(@tags, @encoding, @temporary_directory, @logger)
 
     @rotation = rotation_strategy
 
@@ -387,6 +387,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   def clean_temporary_file(file)
     @logger.debug? && @logger.debug("Removing temporary file", :path => file.path)
     file.delete!
+    @file_repository.stop_tracking_temp_file(file.prefix, file)
   end
 
   # The upload process will use a separate uploader/threadpool with less resource allocated to it.

--- a/lib/logstash/outputs/s3/temporary_file.rb
+++ b/lib/logstash/outputs/s3/temporary_file.rb
@@ -23,10 +23,11 @@ module LogStash
 
         attr_reader :fd
 
-        def initialize(key, fd, temp_path)
+        def initialize(key, fd, temp_path, prefix)
           @fd = fd
           @key = key
           @temp_path = temp_path
+          @prefix = prefix
           @created_at = Time.now
         end
 
@@ -53,6 +54,10 @@ module LogStash
 
         def key
           @key.gsub(/^\//, "")
+        end
+
+        def prefix
+          @prefix
         end
 
         # Each temporary file is created inside a directory named with an UUID,
@@ -82,7 +87,7 @@ module LogStash
           end
           TemporaryFile.new(key_parts.slice(1, key_parts.size).join("/"),
                             ::File.exist?(file_path) ? ::File.open(file_path, "r") : nil, # for the nil case, file size will be 0 and upload will be ignored.
-                            ::File.join(temporary_folder, key_parts.slice(0, 1)))
+                            ::File.join(temporary_folder, key_parts.slice(0, 1)), "")
         end
 
         def self.gzip_extension

--- a/lib/logstash/outputs/s3/temporary_file_factory.rb
+++ b/lib/logstash/outputs/s3/temporary_file_factory.rb
@@ -21,7 +21,7 @@ module LogStash
         FILE_MODE = "a"
         STRFTIME = "%Y-%m-%dT%H.%M"
 
-        attr_accessor :counter, :tags, :prefix, :encoding, :temporary_directory, :current
+        attr_accessor :counter, :tags, :prefix, :encoding, :temporary_directory, :current, :temp_files
 
         def initialize(prefix, tags, encoding, temporary_directory)
           @counter = 0
@@ -31,6 +31,7 @@ module LogStash
           @encoding = encoding
           @temporary_directory = temporary_directory
           @lock = Mutex.new
+          @temp_files = Array.new
 
           rotate!
         end
@@ -38,6 +39,7 @@ module LogStash
         def rotate!
           @lock.synchronize {
             @current = new_file
+            @temp_files.push(@current)
             increment_counter
             @current
           }
@@ -86,7 +88,7 @@ module LogStash
                  ::File.open(::File.join(path, key), FILE_MODE)
                end
 
-          TemporaryFile.new(key, io, path)
+          TemporaryFile.new(key, io, path, prefix)
         end
 
         class IOWrappedGzip


### PR DESCRIPTION
### Description
This PR mainly focuses on two changes:
1. Tracks every created temp files make sure they are removed.
Introduced `temp_files` container (`FileRepository` locks for thread safety) to keep and track all rotated files. When file is removed from track list?
- when recently created file becomes stale, means no event written to the file
- 

When file and tempdir are physically deleted?
- when uploaded to S3 - both temp dir and file are deleted.
- when becomes stale: no event written to the file during 15 mins - both temp dir and file are deleted.
- !NEW: deleting file (`file.delete!`) didn't succeed, means third party process (especially on Windows, security scanners) is keeping open the IO and Logstash removes the file. Physically, for this case, file will be deleted but temp dir stays. - both temp dir is deleted.

<span style="color:green">asdas
```diff
+def remove_staled_files
+  with_lock do |factory|
+    factory.temp_files = factory.temp_files.delete_if do |temp_file|
+     is_staled = temp_file.size == 0 && (Time.now - temp_file.ctime > @stale_time)
+      is_temp_dir_empty = false
+     begin
+        # checking Dir emptiness and remove file
+        # reading file and checking size doesn't make sense as it will not possible after temp_file.size == 0 filter
+        temp_file.delete! if is_staled
+        is_temp_dir_empty = Dir.empty?(::File.join(temp_file.temp_path, temp_file.prefix)) unless is_staled
+        temp_file.delete! if is_temp_dir_empty
+      rescue => e
+        @logger.error("An error occurred while sweeping temp dir.", :exception => e.class, :message => e.message, :path => temp_file.path, :backtrace => e.backtrace)
+      end
+      is_staled || is_temp_dir_empty
+    end
+    # mark as deleted once we finish tracking all temp files created
+    @is_deleted = factory.temp_files.length == 0
+  end
+end
```
</span>

2. Moves the periodic stale sweeper to higher level, same level as periodic file rotator to make KISS. Also, confusing codes are cleaned such as properly namings (ex: periodic file rotator, periodic file sweeper), correcting misleading comments/log-descriptions.

