### PR TITLE
Update list of possible S3 storage classes

### DIFF
--- a/docs/output-s3.asciidoc
+++ b/docs/output-s3.asciidoc
@@ -107,7 +107,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-signature_version>> |<<string,string>>, one of `["v2", "v4"]`|No
 | <<plugins-{type}s-{plugin}-size_file>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-ssekms_key_id>> |<<string,string>>|No
-| <<plugins-{type}s-{plugin}-storage_class>> |<<string,string>>, one of `["STANDARD", "REDUCED_REDUNDANCY", "STANDARD_IA", "ONEZONE_IA"]`|No
+| <<plugins-{type}s-{plugin}-storage_class>> |<<string,string>>, one of `["STANDARD", "REDUCED_REDUNDANCY", "STANDARD_IA", "ONEZONE_IA", "INTELLIGENT_TIERING", "GLACIER", "DEEP_ARCHIVE", "OUTPOSTS", "GLACIER_IR", "SNOW", "EXPRESS_ONEZONE"]`|No
 | <<plugins-{type}s-{plugin}-temporary_directory>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-time_file>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-upload_multipart_threshold>> |<<number,number>>|No
@@ -375,7 +375,7 @@ http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html
 [id="plugins-{type}s-{plugin}-storage_class"]
 ===== `storage_class` 
 
-  * Value can be any of: `STANDARD`, `REDUCED_REDUNDANCY`, `STANDARD_IA`, `ONEZONE_IA`
+  * Value can be any of: `STANDARD`, `REDUCED_REDUNDANCY`, `STANDARD_IA`, `ONEZONE_IA`, `INTELLIGENT_TIERING`, `GLACIER`, `DEEP_ARCHIVE`, `OUTPOSTS`, `GLACIER_IR`, `SNOW`, `EXPRESS_ONEZONE`
   * Default value is `"STANDARD"`
 
 Specifies what S3 storage class to use when uploading the file.

--- a/lib/logstash/outputs/s3.rb
+++ b/lib/logstash/outputs/s3.rb
@@ -142,7 +142,7 @@ class LogStash::Outputs::S3 < LogStash::Outputs::Base
   # More information about the different storage classes can be found:
   # http://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html
   # Defaults to STANDARD.
-  config :storage_class, :validate => ["STANDARD", "REDUCED_REDUNDANCY", "STANDARD_IA", "ONEZONE_IA"], :default => "STANDARD"
+  config :storage_class, :validate => ["STANDARD", "REDUCED_REDUNDANCY", "STANDARD_IA", "ONEZONE_IA", "INTELLIGENT_TIERING", "GLACIER", "DEEP_ARCHIVE", "OUTPOSTS", "GLACIER_IR", "SNOW", "EXPRESS_ONEZONE"], :default => "STANDARD"
 
   # Set the directory where logstash will store the tmp files before sending it to S3
   # default to the current OS temporary directory in linux /tmp/logstash

--- a/spec/outputs/s3_spec.rb
+++ b/spec/outputs/s3_spec.rb
@@ -122,7 +122,7 @@ describe LogStash::Outputs::S3 do
 
     describe "Storage Class" do
       context "when configured" do
-        ["STANDARD", "REDUCED_REDUNDANCY", "STANDARD_IA", "ONEZONE_IA"].each do |storage_class|
+        ["STANDARD", "REDUCED_REDUNDANCY", "STANDARD_IA", "ONEZONE_IA", "INTELLIGENT_TIERING", "GLACIER", "DEEP_ARCHIVE", "OUTPOSTS", "GLACIER_IR", "SNOW", "EXPRESS_ONEZONE"].each do |storage_class|
           it "should return the configured storage class: #{storage_class}" do
             s3 = described_class.new(options.merge({ "storage_class" => storage_class }))
             expect(s3.upload_options).to include(:storage_class => storage_class)


### PR DESCRIPTION
## Release notes

Added the Intelligent-Tiering, Glacier Flexible Retrieval, Glacier Deep Archive, Outposts, Glacier Instant Retrieval, Snow, and Express One Zone S3 storage classes

## What does this PR do?

Updates the list of possible S3 storage classes to the full list available from Amazon:
https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#AmazonS3-PutObject-request-header-StorageClass

## Why is it important/What is the impact to the user?

Allows use of the full range of S3 storage classes available.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] ~~I have commented my code, particularly in hard-to-understand areas~~
- [x] I have made corresponding changes to the documentation
- [x] ~~I have made corresponding change to the default configuration files (and/or docker env variables)~~
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~

## Related issues

- Closes #38