### PR TITLE
Add `cutoff_second` configuration option to S3 input plugin

### DIFF
--- a/docs/input-s3.asciidoc
+++ b/docs/input-s3.asciidoc
@@ -62,6 +62,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-backup_to_bucket>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-backup_to_dir>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-bucket>> |<<string,string>>|Yes
+| <<plugins-{type}s-{plugin}-cutoff_second>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-delete>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-endpoint>> |<<string,string>>|No
@@ -177,6 +178,16 @@ Path of a local directory to backup processed files to.
   * There is no default value for this setting.
 
 The name of the S3 bucket.
+
+[id="plugins-{type}s-{plugin}-cutoff_second"]
+===== `cutoff_second` 
+
+  * Value type is <<number,number>>
+  * Default value is `3`
+
+The time window in seconds used to filter recently modified S3 objects. 
+Objects modified within this cutoff period may be skipped.
+Value is in seconds.
 
 [id="plugins-{type}s-{plugin}-delete"]
 ===== `delete` 

--- a/spec/inputs/s3_spec.rb
+++ b/spec/inputs/s3_spec.rb
@@ -23,7 +23,7 @@ describe LogStash::Inputs::S3 do
       "sincedb_path" => File.join(sincedb_path, ".sincedb")
     }
   }
-  let(:cutoff) { LogStash::Inputs::S3::CUTOFF_SECOND }
+  let(:cutoff) { 3 }
 
 
   before do


### PR DESCRIPTION
## Summary

This PR introduces a new configuration option `cutoff_second` to the Logstash AWS S3 input plugin. It allows users to control the cutoff window (in seconds) for filtering recently modified S3 objects.

Previously, this value was hardcoded as a constant. Now it's configurable, providing more flexibility and better handling of object missing.
There are cases where the difference between the creation time of a file in S3 and the time it's listed can exceed 20 seconds, resulting in missing processing of files with the same creation time.
To prevent missing files, add a feature that allows you to set the CUTOFF_SECOND value within the S3 input plugin, rather than fixing it to 3.

## Changes

- Added `cutoff_second` as a `config` parameter (default: `3`)
- Replaced `CUTOFF_SECOND` constant with `@cutoff_second` usage
- Updated `docs/input-s3.asciidoc`:
  - Added entry in `S3 Input Configuration Options` table
  - Added detailed explanation under `==== cutoff_second`
- Updated unit test:
  - change from LogStash::Inputs::S3::CUTOFF_SECOND to 3 in unit test

## Usage

```ruby
input {
  s3 {
    bucket => "mybucket"
    access_key_id => "mykey"
    secret_access_key => "mysecret"
    cutoff_second => 30
  }
}